### PR TITLE
Added 'update-end' event to REGION_EVENTS

### DIFF
--- a/src/models/Events.js
+++ b/src/models/Events.js
@@ -68,6 +68,7 @@ export const REGION_EVENTS = [
   'out',
   'remove',
   'update',
+  'update-end',
   'click',
   'dbclick',
   'over',


### PR DESCRIPTION
According to [WaveSurfer documentation](https://wavesurfer-js.org/plugins/regions.html) there is a region level 'update-end' event that is missing in your REGION_EVENTS (you have region-update-end in REGIONS_EVENTS, but it is not the same). Could you please add it?