### PR TITLE
Fix event handlers to trigger only once per second

### DIFF
--- a/src/components/Waveform/index.js
+++ b/src/components/Waveform/index.js
@@ -91,8 +91,7 @@ export default class Waveform extends React.Component {
     }
 
     registerEvent(this._wavesurfer, EVENT.AUDIO_PROCESS, pos => {
-      let currentTime = Math.ceil(pos);
-      if (currentTime !== this.props.pos) {
+      if (Math.ceil(pos) !== Math.ceil(this.props.pos)) {
         this.props.onPosChange({
           wavesurfer: this._wavesurfer,
           originalArgs: [pos]
@@ -102,9 +101,8 @@ export default class Waveform extends React.Component {
 
     registerEvent(this._wavesurfer, EVENT.SEEK, pos => {
       let duration = this._wavesurfer.getDuration();
-      let currentTime = Math.ceil(duration*pos);
 
-      if (currentTime !== this.props.pos) {
+      if (Math.ceil(duration * pos) !== Math.ceil(this.props.pos)) {
         this.props.onPosChange({
           wavesurfer: this._wavesurfer,
           originalArgs: [pos]

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,10 @@ export default class ReactWaves extends React.Component {
 
     if (this.props.onPosChange) {
       this.props.onPosChange(pos, e.wavesurfer);
-    } else if (pos && pos !== this.state.pos) {
+    }
+
+    // We always update this.state.pos, because it is used for comparison in Waveform's AUDIO_PROCESS event handler
+    if (pos && pos !== this.state.pos) {
       this.setState({
         pos,
         duration


### PR DESCRIPTION
Closes #26

I think the intent of this code was to call `onPosChange` only once per second.

But while `currentTime` has been converted into a whole number, `this.props.pos` was still fractional! So the comparison was always failing, and the callback was always being called.

This was causing too much work in JavaScript, and producing audible crackle on some devices.

So I fixed the comparison to trigger only once per second, as originally intended.

- I put both the `ceil()` calls on the same line, to make it clearer that we are comparing two integers.