### PR TITLE
Return pos of SEEK event as seconds

### DIFF
--- a/src/components/Waveform/index.js
+++ b/src/components/Waveform/index.js
@@ -106,7 +106,7 @@ export default class Waveform extends React.Component {
       if (Math.ceil(duration * pos) !== Math.ceil(this.props.pos)) {
         this.props.onPosChange({
           wavesurfer: this._wavesurfer,
-          originalArgs: [pos],
+          originalArgs: [duration * pos],
         });
       }
     });


### PR DESCRIPTION
Changed the returned pos triggered by the SEEK event to return the position in seconds (instead of a fraction) just like the AUDIO_PROCESS event does