### PR TITLE
Add typescript types definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -64,7 +64,24 @@ export type ReactWavesProps = {
     xhr?: object;
   };
   spectrogramOptions?: object;
-  timelineOptions?: object;
+  timelineOptions?: {
+    container?: string | HTMLElement;
+    pixelRatio?: number;
+    zoomDebounce?: number;
+    height?: number;
+    duration?: number;
+    notchPercentHeight?: number;
+    timeInterval?: (pixels: number) => number;
+    primaryLabelInterval?: (pixels: number) => number;
+    secondaryLabelInterval?: (pixels: number) => number;
+    offset?: number;
+    primaryColor?: string;
+    fontSize?: string;
+    fontFamily?: string;
+    primaryFontColor?: string;
+    labelPadding?: number;
+    unlabeledNotchColor?: string;
+  };
   children?: ReactNode;
 };
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,7 @@ export type ReactWavesProps = {
     barGap?: number;
     barHeight?: number;
     barRadius?: number;
-    barWidth?: (props: object, propName: string, componentName: string) => void;
+    barWidth?: number;
     closeAudioContext?: boolean;
     cursorColor?: string;
     cursorWidth?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,27 @@
-import { CSSProperties } from 'react';
+import { CSSProperties, ReactElement } from "react";
 
-export interface IReactWaves {
+export type Region = {
+  id?: string;
+  start?: number;
+  end?: number;
+  loop?: boolean;
+  drag?: boolean;
+  resize?: boolean;
+  color?: string;
+};
+
+export type RegionProps = {
+  regions: Region[];
+};
+
+export declare function Regions(props: RegionProps): ReactElement | null;
+
+export type ReactWavesProps = {
   style?: CSSProperties;
   className?: string;
   playing?: boolean;
   pos?: number;
-  audioFile?: (props: object, propName: string, componentName: string) => void;
+  audioFile?: File | Blob | string;
   mediaElt?: string | HTMLElement;
   audioPeaks?: number[];
   volume?: number;
@@ -20,11 +36,7 @@ export interface IReactWaves {
     barGap?: number;
     barHeight?: number;
     barRadius?: number;
-    barWidth?: (
-      props: object,
-      propName: string,
-      componentName: string
-    ) => void;
+    barWidth?: (props: object, propName: string, componentName: string) => void;
     closeAudioContext?: boolean;
     cursorColor?: string;
     cursorWidth?: number;
@@ -53,4 +65,9 @@ export interface IReactWaves {
   };
   spectrogramOptions?: object;
   timelineOptions?: object;
-}
+  children?: ReactNode;
+};
+
+declare function ReactWaves(props: ReactWavesProps): ReactElement;
+
+export default ReactWaves;

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@dschoon/react-waves",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "React component wrapper for wavesurfer.js",
   "author": "dschoon",
   "license": "MIT",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/dschoon/react-waves"
@@ -61,7 +62,8 @@
     "webpack": "4.44.2"
   },
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ],
   "dependencies": {
     "@types/jest": "^26.0.15",

--- a/src/index.js
+++ b/src/index.js
@@ -163,4 +163,3 @@ ReactWaves.defaultProps = {
 };
 
 export * from "./components/Plugins/regions";
-export * from "./models/IReactWaves.ts";


### PR DESCRIPTION
Add typescript types definitions. 

Unfortunately your current method `import { IReactWaves }` doesn't work. You need to add a type definition (a file ending with d.ts) and add a "types" field in package.json

This is a first attempt. At least, with it, basic functionality works in a TS project, but probably not advanced (for example, Region events are not declared).

With this PR, typescript users of this package don't need to do anything. It just works:

This is a valid typescript example:

```ts
import ReactWaves, { Regions } from "@dschoon/react-waves";

type Props = {
  file: string | File | Blob
}

const MyWaveComponent: React.FC<Props> = ({ file }) => (
    <ReactWaves
      audioFile={file}
      options={{
        barHeight: 2,
        cursorWidth: 0,
        height: 200,
        hideScrollbar: true,
        progressColor: "#EC407A",
        responsive: true,
        waveColor: "#D1D6DA",
      }}
      volume={1}
      zoom={1}
      playing={false}
    >
      <Regions regions={[{ start: 0, end: 1 }]} />
    </ReactWaves>
)
```